### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/home/profiles/graphical/applications/firefox/search/default.nix
+++ b/home/profiles/graphical/applications/firefox/search/default.nix
@@ -80,8 +80,8 @@ in
       icon = "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
     };
     "NixOS Wiki" = {
-      urls = [ { template = "https://nixos.wiki/index.php?search={searchTerms}"; } ];
-      iconUpdateURL = "https://nixos.wiki/favicon.png";
+      urls = [ { template = "https://wiki.nixos.org/index.php?search={searchTerms}"; } ];
+      iconUpdateURL = "https://wiki.nixos.org/favicon.png";
       # TODO: why?
       updateInterval = 24 * 60 * 60 * 1000; # every day
       definedAliases = [ "@nwiki" ];

--- a/nixos/profiles/audio-pro.nix
+++ b/nixos/profiles/audio-pro.nix
@@ -1,6 +1,6 @@
 # <https://discourse.nixos.org/t/usb-audio-interface-not-recognized/35159>
 # <https://wiki.archlinux.org/index.php/Pro_Audio>
-# <https://nixos.wiki/wiki/PipeWire>
+# <https://wiki.nixos.org/wiki/PipeWire>
 # possible conflict with musnix rt kernel + nvidia proprietary driver: <https://github.com/musnix/musnix/issues/127>
 { flake, ... }:
 {

--- a/users/cdom/config/tridactyl/tridactylrc
+++ b/users/cdom/config/tridactyl/tridactylrc
@@ -66,7 +66,7 @@ set searchurls.gh https://github.com/search?q=
 set searchurls.mdn https://developer.mozilla.org/en-US/search?q=%s
 set searchurls.nix https://noogle.dev/?term=%22%s%22
 set searchurls.nixpkgs https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20%s
-set searchurls.nixwiki https://nixos.wiki/index.php?search=
+set searchurls.nixwiki https://wiki.nixos.org/index.php?search=
 set searchurls.npm https://bundlephobia.com/package/%s
 set searchurls.opts https://search.nixos.org/options?query=
 set searchurls.pkgs https://search.nixos.org/packages?query=


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️